### PR TITLE
fix: 添加无障碍访问支持

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -71,46 +71,46 @@ const minPasswordLength = computed(() => {
   <main>
     <PasswordBox v-model="password" />
     <div class="input-wrapper">
-      <span class="label">
+      <label class="label" id="label-length">
         密码长度：
-      </span>
-      <RangeInput v-model="passwordLength" :min="minPasswordLength" :max="100" />
+      </label>
+      <RangeInput v-model="passwordLength" :min="minPasswordLength" :max="100" aria-labelledby="label-length" />
     </div>
     <div class="input-wrapper">
-      <span class="label">
+      <label class="label" id="label-number">
         包含数字：
-      </span>
-      <SwitchInput v-model="config.includeNumber" />
+      </label>
+      <SwitchInput v-model="config.includeNumber" aria-labelledby="label-number" />
     </div>
     <div class="input-wrapper">
-      <span class="label">
+      <label class="label" id="label-lowercase">
         包含小写字母：
-      </span>
-      <SwitchInput v-model="config.includeLowercase" />
+      </label>
+      <SwitchInput v-model="config.includeLowercase" aria-labelledby="label-lowercase" />
     </div>
     <div class="input-wrapper">
-      <span class="label">
+      <label class="label" id="label-uppercase">
         包含大写字母：
-      </span>
-      <SwitchInput v-model="config.includeUppercase" />
+      </label>
+      <SwitchInput v-model="config.includeUppercase" aria-labelledby="label-uppercase" />
     </div>
     <div class="input-wrapper">
-      <span class="label">
+      <label class="label" id="label-symbol">
         包含特殊符号：
-      </span>
-      <SwitchInput v-model="config.includeSymbol" />
+      </label>
+      <SwitchInput v-model="config.includeSymbol" aria-labelledby="label-symbol" />
     </div>
     <div class="flex flex-col gap-2">
       <div class="input-wrapper">
-        <span class="label">
+        <label class="label" id="label-ignore">
           排除字符：
-        </span>
-        <SwitchInput v-model="config.ignoreChars" />
+        </label>
+        <SwitchInput v-model="config.ignoreChars" aria-labelledby="label-ignore" />
       </div>
       <input class="ignore-input" :class="{ hide: !config.ignoreChars }" type="text" v-model="ignoreChars" />
     </div>
     <button class="block-btn" @click="refreshPassword">生成密码</button>
-    <div v-if="security.length !== 0" class="security-wrapper">
+    <div v-if="security.length !== 0" class="security-wrapper" aria-live="polite">
       <div class="security-item" :class="[item.type]" v-for="item in security" :key="item.text">
         <div v-if="item.type == 'warn'" class="icon i-mingcute:alert-fill"></div>
         <div v-if="item.type == 'error'" class="icon i-mingcute:alert-octagon-fill"></div>

--- a/src/components/PasswordBox.vue
+++ b/src/components/PasswordBox.vue
@@ -19,7 +19,7 @@ const copy = () => {
             'w-full': password.trim().length === 0
         }" />
         <div class="action-area">
-            <button class="btn copy-btn" @click="copy">
+            <button class="btn copy-btn" aria-label="复制密码" @click="copy">
                 <div class="i-mingcute:copy-fill"></div>
             </button>
         </div>

--- a/src/components/RangeInput.vue
+++ b/src/components/RangeInput.vue
@@ -64,7 +64,7 @@ const onPointerUp = (event: PointerEvent) => {
         <div class="slider-wrapper">
             <div ref="sliderRef" class="slider" :style="{
                 '--precent': currentPrecent
-            }" :class="{ active: isListening }" @pointerdown="onPointerDown">
+            }" :class="{ active: isListening }" role="slider" :aria-valuemin="min" :aria-valuemax="max" :aria-valuenow="value" tabindex="0" @pointerdown="onPointerDown" @keydown.left.prevent="value = Math.max(min, value - 1)" @keydown.down.prevent="value = Math.max(min, value - 1)" @keydown.right.prevent="value = Math.min(max, value + 1)" @keydown.up.prevent="value = Math.min(max, value + 1)">
                 <div class="slider__bar"></div>
                 <div class="slider__button"></div>
                 <div class="slider__protip">{{ value }}</div>

--- a/src/components/SwitchInput.vue
+++ b/src/components/SwitchInput.vue
@@ -12,7 +12,7 @@ const state = useModel(props, 'modelValue')
 <template>
     <div class="switch-wrapper" :class="{
         active: state,
-    }" @click.prevent="state = !state">
+    }" role="switch" :aria-checked="state" tabindex="0" @click.prevent="state = !state" @keydown.enter.prevent="state = !state" @keydown.space.prevent="state = !state">
         <div class="switch__track">
             <div class="switch__inner">
                 <div class="switch__trumb"></div>


### PR DESCRIPTION
## 改进内容

### ♿ 屏幕阅读器支持
- SwitchInput: role=switch, aria-checked
- RangeInput: role=slider, aria-valuemin/max/now
- PasswordBox: 复制按钮 aria-label

### ⌨️ 键盘导航
- SwitchInput: Enter/Space 切换
- RangeInput: 方向键调整值

### 🏷️ 语义化
- 将 span 标签改为 label 并关联控件
- 添加 aria-live 区域用于安全警告

---

**影响**: 残障用户现在可以正常使用密码生成器